### PR TITLE
fix: Correct project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ license-files = ["LICENSE", "NOTICE"]
 version = "0.6.0"
 
 [project.urls]
-Home = "https://github.com/capitalone/c1-slingshot-sdk-py"
-Changelog = "https://github.com/capitalone/c1-slingshot-sdk-py/blob/main/CHANGELOG.md"
+Home = "https://github.com/capitalone/c1s-slingshot-sdk-py"
+Changelog = "https://github.com/capitalone/c1s-slingshot-sdk-py/blob/main/docs/changelog.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
A quick fix to correct the url pathing for documentation and repository.